### PR TITLE
[duplicate] feat: Optionally fall back to CWD as default path in file dialogs

### DIFF
--- a/src/vs/platform/dialogs/electron-main/dialogMainService.ts
+++ b/src/vs/platform/dialogs/electron-main/dialogMainService.ts
@@ -89,7 +89,7 @@ export class DialogMainService implements IDialogMainService {
 		};
 
 		// Ensure defaultPath
-		dialogOptions.defaultPath = options.defaultPath || this.stateService.getItem<string>(DialogMainService.workingDirPickerStorageKey) ||  process.cwd();
+		dialogOptions.defaultPath = options.defaultPath || this.stateService.getItem<string>(DialogMainService.workingDirPickerStorageKey);
 
 
 		// Ensure properties

--- a/src/vs/platform/dialogs/electron-main/dialogMainService.ts
+++ b/src/vs/platform/dialogs/electron-main/dialogMainService.ts
@@ -89,7 +89,7 @@ export class DialogMainService implements IDialogMainService {
 		};
 
 		// Ensure defaultPath
-		dialogOptions.defaultPath = options.defaultPath || this.stateService.getItem<string>(DialogMainService.workingDirPickerStorageKey);
+		dialogOptions.defaultPath = options.defaultPath || this.stateService.getItem<string>(DialogMainService.workingDirPickerStorageKey) ||  process.cwd();
 
 
 		// Ensure properties

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -214,6 +214,12 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 				'description': localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity."),
 				ignoreSync: true
 			},
+			'window.cwdDefaultPath': {
+				'type': 'boolean',
+				'default': false,
+				'description': localize('cwdDefaultPath', "Use the current working directory as default file dialog location. When disabled, the current user\'s home directory will be used."),
+				ignoreSync: true
+			},
 			'window.newWindowDimensions': {
 				'type': 'string',
 				'enum': ['default', 'inherit', 'offset', 'maximized', 'fullscreen'],

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -26,7 +26,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { Schemas } from 'vs/base/common/network';
 import { PLAINTEXT_EXTENSION } from 'vs/editor/common/modes/modesRegistry';
-import { cwd } from 'vs/base/common/process';
+import { env } from 'vs/base/common/process';
 
 export abstract class AbstractFileDialogService implements IFileDialogService {
 
@@ -62,8 +62,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && cwd()) {
-				return this.pathService.fileURI(cwd());
+			if (shouldUseCwd && env['VSCODE_CWD']) {
+				return this.pathService.fileURI(env['VSCODE_CWD']);
 			}
 			candidate = await this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		}
@@ -83,8 +83,9 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && cwd()) {
-				return this.pathService.fileURI(cwd());
+			if (shouldUseCwd && env['VSCODE_CWD']) {
+
+				return this.pathService.fileURI(env['VSCODE_CWD']);
 			}
 			return this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		} else {

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -26,6 +26,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { Schemas } from 'vs/base/common/network';
 import { PLAINTEXT_EXTENSION } from 'vs/editor/common/modes/modesRegistry';
+import { cwd } from 'vs/base/common/process';
 
 export abstract class AbstractFileDialogService implements IFileDialogService {
 
@@ -61,8 +62,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && process.env['VSCODE_CWD']) {
-				return this.pathService.fileURI(process.env['VSCODE_CWD']);
+			if (shouldUseCwd && cwd()) {
+				return this.pathService.fileURI(cwd());
 			}
 			candidate = await this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		}
@@ -82,8 +83,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && process.env['VSCODE_CWD']) {
-				return this.pathService.fileURI(process.env['VSCODE_CWD']);
+			if (shouldUseCwd && cwd()) {
+				return this.pathService.fileURI(cwd());
 			}
 			return this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		} else {

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -61,7 +61,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && process.env['VSCODE_CWD'])	{
+			if (shouldUseCwd && process.env['VSCODE_CWD']) {
 				return this.pathService.fileURI(process.env['VSCODE_CWD']);
 			}
 			candidate = await this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
@@ -82,7 +82,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && process.env['VSCODE_CWD'])	{
+			if (shouldUseCwd && process.env['VSCODE_CWD']) {
 				return this.pathService.fileURI(process.env['VSCODE_CWD']);
 			}
 			return this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -26,7 +26,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { Schemas } from 'vs/base/common/network';
 import { PLAINTEXT_EXTENSION } from 'vs/editor/common/modes/modesRegistry';
-import { env } from 'vs/base/common/process';
+import { cwd, env } from 'vs/base/common/process';
 
 export abstract class AbstractFileDialogService implements IFileDialogService {
 
@@ -62,8 +62,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && env['VSCODE_CWD']) {
-				return this.pathService.fileURI(env['VSCODE_CWD']);
+			if (shouldUseCwd && (env['VSCODE_CWD'] || cwd())) {
+				return this.pathService.fileURI(env['VSCODE_CWD'] || cwd());
 			}
 			candidate = await this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		}
@@ -83,9 +83,8 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 
 		if (!candidate) {
 			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
-			if (shouldUseCwd && env['VSCODE_CWD']) {
-
-				return this.pathService.fileURI(env['VSCODE_CWD']);
+			if (shouldUseCwd && (env['VSCODE_CWD'] || cwd())) {
+				return this.pathService.fileURI(env['VSCODE_CWD'] || cwd());
 			}
 			return this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		} else {

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -60,6 +60,10 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 		}
 
 		if (!candidate) {
+			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
+			if (shouldUseCwd && process.env['VSCODE_CWD'])	{
+				return this.pathService.fileURI(process.env['VSCODE_CWD']);
+			}
 			candidate = await this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		}
 
@@ -77,6 +81,10 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 		}
 
 		if (!candidate) {
+			const shouldUseCwd = await this.configurationService.getValue<boolean>('window.cwdDefaultPath');
+			if (shouldUseCwd && process.env['VSCODE_CWD'])	{
+				return this.pathService.fileURI(process.env['VSCODE_CWD']);
+			}
 			return this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		} else {
 			return resources.dirname(candidate);


### PR DESCRIPTION
When opening file dialog with no open project, explicit path, or previously opened location, use the "actual" CWD.

Given the following command line:
```shell
$ cd /etc/potato/projects
$ code --new-window
```
Current behavior when invoking Open File/Folder is for the dialog to initialize in `~/`. This PR introduces the ability to use the current working directory instead.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
